### PR TITLE
Allow running the DNS file update on a remote host

### DIFF
--- a/roles/etc_hosts/defaults/main.yml
+++ b/roles/etc_hosts/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 update_etc_hosts: false
+dns_resolution_file: /etc/hosts

--- a/roles/etc_hosts/tasks/main.yml
+++ b/roles/etc_hosts/tasks/main.yml
@@ -4,17 +4,17 @@
   register: dns_entries
 
 - name: Warn if the API VIP already in {{ dns_resolution_file }}
-  debug:
+  ansible.builtin.debug:
     msg: "WARNING: {{ api_vip }} is already associated with a cluster in {{ dns_resolution_file }}. You might need to update the file manually"
-  when: update_etc_hosts and api_vip in dns_entries
+  when: update_etc_hosts and api_vip in dns_entries.content | b64decode
 
 - name: Warn if the ingress VIP already in {{ dns_resolution_file }}
-  debug:
+  ansible.builtin.debug:
     msg: "WARNING: {{ ingress_vip }} is already associated with a cluster in {{ dns_resolution_file }}. You might need to update the file manually"
-  when: update_etc_hosts and ingress_vip in dns_entries
+  when: update_etc_hosts and ingress_vip in dns_entries.content | b64decode
 
 - name: Update API VIP in "{{ dns_resolution_file }}"
-  replace:
+  ansible.builtin.replace:
     path: "{{ dns_resolution_file }}"
     regexp: "{{ api_vip_regex }}"
     replace: "{{ api_vip }}   \\2"
@@ -27,7 +27,7 @@
   register: _api_vip_update_result
 
 - name: Update ingress VIP in "{{ dns_resolution_file }}"
-  replace:
+  ansible.builtin.replace:
     path: "{{ dns_resolution_file }}"
     regexp: "{{ ingress_vip_regex }}"
     replace: "{{ ingress_vip }}   \\2"
@@ -39,7 +39,7 @@
   when: update_etc_hosts
 
 - name: Add entries to "{{ dns_resolution_file }}" if didn't exist already
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: "{{ dns_resolution_file }}"
     line: |
 
@@ -55,10 +55,10 @@
     group: root
     mode: '0644'
   become: true
-  when: update_etc_hosts and dns_name not in dns_entries
+  when: update_etc_hosts and dns_name not in dns_entries.content | b64decode
   register: _add_entries_result
 
 - name: Inform user of changes in "{{ dns_resolution_file }}"
-  debug:
+  ansible.builtin.debug:
     msg: "IMPORTANT: Your {{ dns_resolution_file }} file has been changed. A backup file was created in the same directory"
   when: _api_vip_update_result.changed or _add_entries_result.changed

--- a/roles/etc_hosts/tasks/main.yml
+++ b/roles/etc_hosts/tasks/main.yml
@@ -1,14 +1,19 @@
+- name: Read current DNS resolution file "{{ dns_resolution_file }}"
+  ansible.builtin.slurp:
+    src: "{{ dns_resolution_file }}"
+  register: dns_entries
+
 - name: Warn if the API VIP already in {{ dns_resolution_file }}
   debug:
     msg: "WARNING: {{ api_vip }} is already associated with a cluster in {{ dns_resolution_file }}. You might need to update the file manually"
-  when: update_etc_hosts and api_vip in lookup('file', dns_resolution_file)
+  when: update_etc_hosts and api_vip in dns_entries
 
 - name: Warn if the ingress VIP already in {{ dns_resolution_file }}
   debug:
     msg: "WARNING: {{ ingress_vip }} is already associated with a cluster in {{ dns_resolution_file }}. You might need to update the file manually"
-  when: update_etc_hosts and ingress_vip in lookup('file', dns_resolution_file)
+  when: update_etc_hosts and ingress_vip in dns_entries
 
-- name: Update API VIP in {{ dns_resolution_file }}
+- name: Update API VIP in "{{ dns_resolution_file }}"
   replace:
     path: "{{ dns_resolution_file }}"
     regexp: "{{ api_vip_regex }}"
@@ -21,7 +26,7 @@
   when: update_etc_hosts
   register: _api_vip_update_result
 
-- name: Update ingress VIP in {{ dns_resolution_file }}
+- name: Update ingress VIP in "{{ dns_resolution_file }}"
   replace:
     path: "{{ dns_resolution_file }}"
     regexp: "{{ ingress_vip_regex }}"
@@ -33,7 +38,7 @@
   become: true
   when: update_etc_hosts
 
-- name: Add entries to {{ dns_resolution_file }}
+- name: Add entries to "{{ dns_resolution_file }}" if didn't exist already
   lineinfile:
     path: "{{ dns_resolution_file }}"
     line: |
@@ -50,4 +55,10 @@
     group: root
     mode: '0644'
   become: true
-  when: update_etc_hosts and dns_name not in lookup('file', dns_resolution_file)
+  when: update_etc_hosts and dns_name not in dns_entries
+  register: _add_entries_result
+
+- name: Inform user of changes in "{{ dns_resolution_file }}"
+  debug:
+    msg: "IMPORTANT: Your {{ dns_resolution_file }} file has been changed. A backup file was created in the same directory"
+  when: _api_vip_update_result.changed or _add_entries_result.changed

--- a/roles/etc_hosts/vars/main.yml
+++ b/roles/etc_hosts/vars/main.yml
@@ -1,4 +1,3 @@
 dns_name: "{{ cluster_name }}.{{ openshift_base_domain }}"
 api_vip_regex: "([0-9\\.]+)\\s+(api\\.{{ dns_name | regex_escape() }})"
 ingress_vip_regex: "([0-9\\.]+)\\s+([a-z0-9\\-\\.]+\\.apps\\.{{ dns_name | regex_escape() }})"
-dns_resolution_file: /etc/hosts


### PR DESCRIPTION
Check the contents of a remote DNS resolution file when modifying it - instead of a local one. This is useful for running the `etc_hosts` role on a remote system (e.g. using `delegate_to`)